### PR TITLE
 Require product in task payloads and set it as a property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 target/
 
 *.db
+MANIFEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ install:
 
 script:
     - tox -e py27
+
+after_success:
     - tox -e py27-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+
+sudo: false
+
 python:
     - "2.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-sudo: false
-
 python:
     - "2.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ install:
     - sudo apt-add-repository -y ppa:travis-ci/sqlite3
     - sudo apt-get update
     - sudo apt-get install sqlite3
-    - python setup.py install
-    - pip install pyflakes nose mock
+    - travis_retry pip install tox==1.8
 
 script:
-    - pyflakes .
-    - nosetests
+    - tox -e py27
+    - tox -e py27-coveralls

--- a/bbb/servicebase.py
+++ b/bbb/servicebase.py
@@ -269,9 +269,6 @@ class BuildbotDb(object):
         properties = payload.get('properties', {})
         # Always create a property for the taskId
         properties['taskId'] = taskid
-        # And for product, see bug 1195751 for background
-        if "product" not in properties:
-            properties["product"] = payload["product"]
         self.createBuildSetProperties(buildsetid, properties)
 
         # Create the buildrequest

--- a/bbb/servicebase.py
+++ b/bbb/servicebase.py
@@ -79,7 +79,8 @@ class BBBDb(object):
             self.db = sa.create_engine(uri, pool_size=1, pool_recycle=60)
 
         metadata = sa.MetaData(self.db)
-        self.tasks_table = sa.Table('tasks', metadata,
+        self.tasks_table = sa.Table(
+            'tasks', metadata,
             sa.Column('buildrequestId', sa.Integer, primary_key=True),
             sa.Column('taskId', sa.String(32), index=True),
             sa.Column('runId', sa.Integer),
@@ -171,7 +172,7 @@ class BuildbotDb(object):
 
     def isBuildRequestComplete(self, brid):
         q = sa.select([self.buildrequests_table.c.complete])\
-              .where(self.buildrequests_table.c.id==brid)
+              .where(self.buildrequests_table.c.id == brid)
         return bool(self.db.execute(q).fetchall()[0][0])
 
     def getBuildRequests(self, buildnumber, buildername, claimed_by_name, claimed_by_incarnation):
@@ -179,29 +180,29 @@ class BuildbotDb(object):
         # TODO: Using complete=0 sucks a bit. If builds complete before we process
         # the build started event, this query doesn't work.
         q = sa.select([self.buildrequests_table.c.id])\
-              .where(self.builds_table.c.number==buildnumber)\
-              .where(self.buildrequests_table.c.id==self.builds_table.c.brid)\
-              .where(self.buildrequests_table.c.complete==0)\
-              .where(self.buildrequests_table.c.buildername==buildername)\
-              .where(self.buildrequests_table.c.claimed_by_name==claimed_by_name)\
-              .where(self.buildrequests_table.c.claimed_by_incarnation==claimed_by_incarnation)
+              .where(self.builds_table.c.number == buildnumber)\
+              .where(self.buildrequests_table.c.id == self.builds_table.c.brid)\
+              .where(self.buildrequests_table.c.complete == 0)\
+              .where(self.buildrequests_table.c.buildername == buildername)\
+              .where(self.buildrequests_table.c.claimed_by_name == claimed_by_name)\
+              .where(self.buildrequests_table.c.claimed_by_incarnation == claimed_by_incarnation)
         ret = self.db.execute(q).fetchall()
         log.debug("getBuildRequests Query took %f seconds", time.time() - now)
         return ret
 
     def getBuildsCount(self, brid):
-        return self.builds_table.count().where(self.builds_table.c.brid==brid).execute().fetchall()[0][0]
+        return self.builds_table.count().where(self.builds_table.c.brid == brid).execute().fetchall()[0][0]
 
     def getBuildIds(self, brid):
         q = sa.select([self.builds_table.c.id])\
-              .where(self.builds_table.c.brid==brid)
+              .where(self.builds_table.c.brid == brid)
         return [row[0] for row in self.db.execute(q).fetchall()]
 
     def getBranch(self, brid):
         q = sa.select([self.sourcestamps_table.c.branch])\
-              .where(self.sourcestamps_table.c.id==self.buildsets_table.c.sourcestampid)\
-              .where(self.buildsets_table.c.id==self.buildrequests_table.c.buildsetid)\
-              .where(self.buildrequests_table.c.id==brid)
+              .where(self.sourcestamps_table.c.id == self.buildsets_table.c.sourcestampid)\
+              .where(self.buildsets_table.c.id == self.buildrequests_table.c.buildsetid)\
+              .where(self.buildrequests_table.c.id == brid)
         r = self.db.execute(q).fetchall()
         if r:
             return r[0][0]
@@ -268,6 +269,9 @@ class BuildbotDb(object):
         properties = payload.get('properties', {})
         # Always create a property for the taskId
         properties['taskId'] = taskid
+        # And for product, see bug 1195751 for background
+        if "product" not in properties:
+            properties["product"] = payload["product"]
         self.createBuildSetProperties(buildsetid, properties)
 
         # Create the buildrequest

--- a/bbb/services.py
+++ b/bbb/services.py
@@ -389,7 +389,7 @@ class TCListener(ListenerService):
         # If the buildername in the payload of the Task doesn't match any of
         # allowed patterns, we can't do anything!
         buildername = tc_task["payload"].get("buildername")
-        product = tc_task["payload"].get("product")
+        product = tc_task["payload"].get("properties", {}).get("product")
 
         if not allow_builder(buildername, self.allowed_builders):
             log.info("Buildername %s in task %s is not part of allowed_builders whitelist, refusing to create BuildRequest", buildername, taskid)
@@ -408,7 +408,8 @@ class TCListener(ListenerService):
         # The script that the Bridge relies on to send build finished events
         # requires that "product" be set in the Buildbot Properties. If it's
         # not provided by the Task, we shouldn't accept the job because it's
-        # unlikely that we'll notice when its Build finishes.
+        # unlikely that we'll notice when its Build finishes. See bug 1195751
+        # for additional background.
         if not product:
             log.info("Task %s has no product set, refusing to create BuildRequest", taskid)
             self.tc_queue.cancelTask(taskid)

--- a/bbb/tcutils.py
+++ b/bbb/tcutils.py
@@ -40,7 +40,7 @@ def createJsonArtifact(queue, taskid, runid, name, data, expires):
         log.error("couldn't upload artifact to s3")
         raise IOError("couldn't upload artifact to s3")
 
+
 def makeTaskId():
     """Used in testing to generate task ids without talking to TaskCluster."""
     return b64encode(uuid4().bytes).replace("+", "-").replace("/", "-").rstrip("=")
-

--- a/bbb/test/dbutils.py
+++ b/bbb/test/dbutils.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 
+
 def makeSchedulerDb(db):
     db.execute(sa.text("""
 CREATE TABLE buildrequests (
@@ -54,4 +55,3 @@ CREATE TABLE buildsets (
                 `results` SMALLINT
             );
 """))
-

--- a/bbb/test/test_services.py
+++ b/bbb/test/test_services.py
@@ -432,7 +432,9 @@ class TestTCListener(unittest.TestCase):
             "created": 50,
             "payload": {
                 "buildername": "builder good name",
-                "product": "foo",
+                "properties": {
+                    "product": "foo",
+                },
                 "sourcestamp": {
                     "branch": "http://foo.com/blah",
                 },
@@ -509,7 +511,9 @@ class TestTCListener(unittest.TestCase):
             "created": 20,
             "payload": {
                 "buildername": "builder good name",
-                "product": "foo",
+                "properties": {
+                    "product": "foo",
+                },
                 "sourcestamp": {
                     "branch": "https://hg.mozilla.org/integration/mozilla-inbound/",
                     "revision": "abcdef123456",

--- a/bbb/test/test_services.py
+++ b/bbb/test/test_services.py
@@ -457,9 +457,10 @@ class TestTCListener(unittest.TestCase):
         self.assertEquals(buildrequests[0].buildername, "builder good name")
         self.assertEquals(buildrequests[0].priority, 0)
         properties = self.tclistener.buildbot_db.buildset_properties_table.select().execute().fetchall()
-        self.assertEquals(len(properties), 1)
-        self.assertEquals(properties[0].property_name, "taskId")
-        self.assertEquals(json.loads(properties[0].property_value), [taskid, "bbb"])
+        self.assertItemsEqual(properties, [
+            (1, u"taskId", u'["{}", "bbb"]'.format(taskid)),
+            (1, u"product", u'["foo", "bbb"]'),
+        ])
 
     @patch("arrow.now")
     def testHandlePendingNewTaskWithHighPriority(self, fake_now):
@@ -477,6 +478,9 @@ class TestTCListener(unittest.TestCase):
             "priority": "high",
             "payload": {
                 "buildername": "i'm a good builder",
+                "properties": {
+                    "product": "foo",
+                },
                 "sourcestamp": {
                     "branch": "http://foo.com/doit",
                 },

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from setuptools import setup
+try:
+    from setuptools import setup
+except:
+    from distutils.core import setup
 
 setup(
     name="bbb",
@@ -20,5 +23,11 @@ setup(
         "kombu",
         "redo",
         "mysql-python",
+    ],
+    tests_require=[
+        "mock",
+        "flake8",
+        "pytest",
+        "pytest-cov",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist = py27
+
+[testenv]
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+deps =
+    flake8
+    pytest
+    pytest-cov
+    mock
+
+commands=
+    flake8 bbb
+    py.test --cov=bbb --cov-report term-missing --doctest-modules bbb
+
+[testenv:py27-coveralls]
+deps=
+    python-coveralls==2.4.3
+commands=
+    coveralls
+
+[flake8]
+exclude = .ropeproject,.tox
+show-source = True
+max-line-length = 160
+
+[pytest]
+norecursedirs = .tox .git .hg
+python_files = test_*.py


### PR DESCRIPTION
(Copying description from original, bad PR at https://github.com/bhearsum/bbb/pull/2)

https://bugzilla.mozilla.org/show_bug.cgi?id=1195751 has a longer explanation of this, but basically product is a required property for the Bridge to work correctly, so I think we should we require it in the Task definitions.

I ended up taking the opportunity to switch to tox and enable coveralls too, apologies for the unrelated parts of this patch. The last hunk of services.py is the code change to support this feature, and the changes to test_services.py are new code to verify it. The rest is pep8/tox changes.

It's worth noting that it's not technically required for incoming task to have product set, since so many Buildbot jobs set it on their own, but if it's not set when the Buildbot Build completes, the bridge never gets a "build finished" notification, ends up confused about the state, and Taskcluster eventually retries the Task. So even though it's not required, I think it's good to validate this up front to make it less likely that we hit this state.

@selenamarie, this one should work!