### PR TITLE
Use a jsonschema to validate payload

### DIFF
--- a/bbb/schemas/payload.yml
+++ b/bbb/schemas/payload.yml
@@ -1,0 +1,77 @@
+id:          http://payload.bbb/v1.schema
+$schema:     http://json-schema.org/draft-04/schema#
+title:       Buildbot Bridge Task Payload
+description: Description of the proper format of a Buildbot Bridge Task payload.
+type:        object
+required:
+    - buildername
+    - properties
+additionalProperties: false
+properties:
+    buildername:
+        title:       Buildbot Builder Name
+        description: |
+            This Builder must exist on the Buildbot master that the Bridge
+            is configured to work with. If not, a BuildRequest will be
+            created for a non-existant Builder, and the Task will never run.
+        type:        string
+        minLength:   1
+    sourcestamp:
+        title:       Buildbot SourceStamp
+        description: |
+            The data to inject into the Buildbot SourceStamp.
+        type:        object
+        required:
+            - branch
+        additionalProperties: false
+        properties:
+            branch:
+                title:       Branch
+                description: |
+                    The "branch" of the build (aka, repo path), eg:
+                    releases/mozilla-beta. Full URL can also be used, but it
+                    will be shortened to repo path. Eg:
+                    http://hg.mozilla.org/releases/mozilla-beta becomes
+                    mozilla-beta.
+                type:        string
+                minLength:   3
+            revision:
+                title:       Revision
+                description: |
+                    The revision of the build. Any valid identifier can be
+                    used, eg: abcdef123456, SOME_TAG_THAT_EXISTS, branchname.
+                type:        string
+                minLength:   1
+            repository:
+                title:       Repository
+                description: SourceStamp repository. Generally unused.
+                type:        string
+                minLength:   1
+            project:
+                title:       Project
+                description: SourceStamp project. Generally unused.
+                type:        string
+                minLength:   1
+    properties:
+        title:       Buildbot Properties
+        description: |
+            Key/Value pairs of Buildbot Properties to include with the Build
+            Request, and eventually passed onto the build. "product" must be
+            included as a property.
+        type:        object
+        required:
+            # The script that the Bridge relies on to send build finished events
+            # requires that "product" be set in the Buildbot Properties. If it's
+            # not provided by the Task, we shouldn't accept the job because it's
+            # unlikely that we'll notice when its Build finishes. See bug 1195751
+            # for additional background.
+            - product
+        additionalProperties: true
+        properties:
+            product:
+                title:       Product Name
+                description: |
+                    Name of the product this Task is for. Required by Buildbot's
+                    postrun script.
+                type:        string
+                minLength:   1

--- a/bbb/schemas/payload.yml
+++ b/bbb/schemas/payload.yml
@@ -1,4 +1,4 @@
-id:          http://payload.bbb/v1.schema
+id:          http://schemas.taskcluster.net/buildbot-bridge/v1/payload.json
 $schema:     http://json-schema.org/draft-04/schema#
 title:       Buildbot Bridge Task Payload
 description: Description of the proper format of a Buildbot Bridge Task payload.

--- a/bbb/services.py
+++ b/bbb/services.py
@@ -411,8 +411,6 @@ class TCListener(ListenerService):
                 self.bbb_db.deleteBuildRequest(our_task.buildrequestId)
             return
 
-        product = tc_task["payload"].get("properties", {}).get("product")
-
         # When Buildbot Builds end up in a RETRY state they are automatically
         # retried against the same BuildRequest. The BuildbotListener reflects
         # this into Taskcluster be calling rerunTask, which creates a new Run

--- a/bbb/services.py
+++ b/bbb/services.py
@@ -1,9 +1,13 @@
+from os import path
 import re
 import time
 
 import arrow
+from jsonschema import Draft4Validator
 from taskcluster.exceptions import TaskclusterRestFailure
+import yaml
 
+from . import schemas
 from .servicebase import ListenerService, ServiceBase, ListenerServiceEvent, SelfserveClient, TaskNotFound
 from .tcutils import createJsonArtifact
 from .timeutils import parseDateString
@@ -354,6 +358,9 @@ class TCListener(ListenerService):
                  provisioner_id, selfserve_url, allowed_builders=(), *args, **kwargs):
         self.allowed_builders = allowed_builders
         self.selfserve = SelfserveClient(selfserve_url)
+        self.payload_schema = Draft4Validator(
+            yaml.load(open(path.join(path.dirname(schemas.__file__), "payload.yml")))
+        )
         events = (
             ListenerServiceEvent(
                 queue_name="%s/task-pending" % pulse_queue_basename,
@@ -386,13 +393,12 @@ class TCListener(ListenerService):
         tc_task = self.tc_queue.task(taskid)
         our_task = self.bbb_db.getTask(taskid)
 
-        # If the buildername in the payload of the Task doesn't match any of
-        # allowed patterns, we can't do anything!
         buildername = tc_task["payload"].get("buildername")
-        product = tc_task["payload"].get("properties", {}).get("product")
+        if not self.payload_schema.is_valid(tc_task["payload"]) or not allow_builder(buildername, self.allowed_builders):
+            log.info("Payload is invalid for task %s, refusing to create BuildRequest", taskid)
+            for e in self.payload_schema.iter_errors(tc_task["payload"]):
+                log.debug(e.message)
 
-        if not allow_builder(buildername, self.allowed_builders):
-            log.info("Buildername %s in task %s is not part of allowed_builders whitelist, refusing to create BuildRequest", buildername, taskid)
             # malformed-payload is the most accurate TC status for this situation
             # but we can't use reportException for cancelling pending tasks,
             # so this will show up as "cancelled" on TC.
@@ -405,18 +411,7 @@ class TCListener(ListenerService):
                 self.bbb_db.deleteBuildRequest(our_task.buildrequestId)
             return
 
-        # The script that the Bridge relies on to send build finished events
-        # requires that "product" be set in the Buildbot Properties. If it's
-        # not provided by the Task, we shouldn't accept the job because it's
-        # unlikely that we'll notice when its Build finishes. See bug 1195751
-        # for additional background.
-        if not product:
-            log.info("Task %s has no product set, refusing to create BuildRequest", taskid)
-            self.tc_queue.cancelTask(taskid)
-            msg.ack()
-            if our_task:
-                self.bbb_db.deleteBuildRequest(our_task.buildrequestId)
-            return
+        product = tc_task["payload"].get("properties", {}).get("product")
 
         # When Buildbot Builds end up in a RETRY state they are automatically
         # retried against the same BuildRequest. The BuildbotListener reflects

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,14 @@ setup(
         "kombu",
         "redo",
         "mysql-python",
+        "jsonschema",
+        "PyYAML",
     ],
     tests_require=[
         "mock",
         "flake8",
         "pytest",
         "pytest-cov",
+        "pytest-capturelog",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,15 @@ setup(
     version="1.2",
     description="Buildbot <-> Taskcluster Bridge",
     author="Mozilla Release Engineering",
-    packages=["bbb"],
+    packages=["bbb", "bbb.schemas"],
     entry_points={
         "console_scripts": [
             "buildbot-bridge = bbb.runner:main",
         ],
     },
+    # Package contains data files -> not safe.
+    zip_safe=False,
+    include_package_data=True,
     install_requires=[
         # Because taskcluster hard pins this version...
         "requests==2.4.3",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except:
 
 setup(
     name="bbb",
-    version="1.2",
+    version="1.3",
     description="Buildbot <-> Taskcluster Bridge",
     author="Mozilla Release Engineering",
     packages=["bbb", "bbb.schemas"],

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     flake8
     pytest
     pytest-cov
+    pytest-capturelog
     mock
 
 commands=


### PR DESCRIPTION
@jonasfj - I put this together at your urging in https://bugzilla.mozilla.org/show_bug.cgi?id=1197291. I'll be fixing that bug itself in another PR, I wanted to keep them separate.

The only thing I'm not sure about here is what to use as the id. There's no place the schema will be remotely available than the repo.