### PR TITLE
Bug 1194767 - use 'nice' slugids

### DIFF
--- a/bbb/tcutils.py
+++ b/bbb/tcutils.py
@@ -1,6 +1,5 @@
-from base64 import b64encode
 import json
-from uuid import uuid4
+import slugid
 
 from redo import retrier
 import requests
@@ -43,4 +42,4 @@ def createJsonArtifact(queue, taskid, runid, name, data, expires):
 
 def makeTaskId():
     """Used in testing to generate task ids without talking to TaskCluster."""
-    return b64encode(uuid4().bytes).replace("+", "-").replace("/", "-").rstrip("=")
+    return slugid.nice()

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "mysql-python",
         "jsonschema",
         "PyYAML",
+        "slugid",
     ],
     tests_require=[
         "mock",


### PR DESCRIPTION
Although Buildbot Bridge is itself not creating taskIds and taskGroupIds itself (as I understand it, since it listens for existing task definitions), it still generates slugIds during testing. In order for the tests to remain aligned with how we are generating slugids in other Taskcluster components, I've updated the Buildbot Bridge tests to use 'nice' slugs too.

To read more about how 'nice' slugs compare to regular v4 slugs, see the [slugid](https://pypi.python.org/pypi/slugid/1.0.6) package.