### PR TITLE
Add MANIFEST.in to fix package building.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include bbb/schemas *

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except:
 
 setup(
     name="bbb",
-    version="1.5.1",
+    version="1.5.3",
     description="Buildbot <-> Taskcluster Bridge",
     author="Mozilla Release Engineering",
     packages=["bbb", "bbb.schemas"],


### PR DESCRIPTION
I think I didn't know what I was doing when I originally created the setup.py. I suspect it continued to work because I had a local cache with payload.yml in it. This seems to work even with the cache blown away:
➜  bbb git:(manifest) ✗ rm -rf *egg* dist
➜  bbb git:(manifest) cat MANIFEST.in 
recursive-include bbb/schemas *
➜  bbb git:(manifest) python setup.py sdist   
running sdist
running egg_info
creating bbb.egg-info
writing pbr to bbb.egg-info/pbr.json
writing requirements to bbb.egg-info/requires.txt
writing bbb.egg-info/PKG-INFO
writing top-level names to bbb.egg-info/top_level.txt
writing dependency_links to bbb.egg-info/dependency_links.txt
writing entry points to bbb.egg-info/entry_points.txt
writing manifest file 'bbb.egg-info/SOURCES.txt'
reading manifest file 'bbb.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'bbb.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt

running check
warning: check: missing required meta-data: url

warning: check: missing meta-data: if 'author' supplied, 'author_email' must be supplied too

creating bbb-1.5.1
creating bbb-1.5.1/bbb
creating bbb-1.5.1/bbb.egg-info
creating bbb-1.5.1/bbb/schemas
making hard links in bbb-1.5.1...
hard linking MANIFEST.in -> bbb-1.5.1
hard linking setup.py -> bbb-1.5.1
hard linking bbb/__init__.py -> bbb-1.5.1/bbb
hard linking bbb/runner.py -> bbb-1.5.1/bbb
hard linking bbb/servicebase.py -> bbb-1.5.1/bbb
hard linking bbb/services.py -> bbb-1.5.1/bbb
hard linking bbb/tcutils.py -> bbb-1.5.1/bbb
hard linking bbb/timeutils.py -> bbb-1.5.1/bbb
hard linking bbb.egg-info/PKG-INFO -> bbb-1.5.1/bbb.egg-info
hard linking bbb.egg-info/SOURCES.txt -> bbb-1.5.1/bbb.egg-info
hard linking bbb.egg-info/dependency_links.txt -> bbb-1.5.1/bbb.egg-info
hard linking bbb.egg-info/entry_points.txt -> bbb-1.5.1/bbb.egg-info
hard linking bbb.egg-info/not-zip-safe -> bbb-1.5.1/bbb.egg-info
hard linking bbb.egg-info/pbr.json -> bbb-1.5.1/bbb.egg-info
hard linking bbb.egg-info/requires.txt -> bbb-1.5.1/bbb.egg-info
hard linking bbb.egg-info/top_level.txt -> bbb-1.5.1/bbb.egg-info
hard linking bbb/schemas/__init__.py -> bbb-1.5.1/bbb/schemas
hard linking bbb/schemas/payload.yml -> bbb-1.5.1/bbb/schemas
Writing bbb-1.5.1/setup.cfg
creating dist
Creating tar archive
removing 'bbb-1.5.1' (and everything under it)
